### PR TITLE
:boom: fix: windows won't find update script

### DIFF
--- a/UpdateDateNTime/AutoStart.vb
+++ b/UpdateDateNTime/AutoStart.vb
@@ -1,9 +1,8 @@
-﻿Imports System.IO
-Imports IWshRuntimeLibrary
+﻿Imports IWshRuntimeLibrary
 
 Public Class AutoStart
     Private Shared ReadOnly startupFolderPath = Environment.GetFolderPath(Environment.SpecialFolder.Startup)
-    Private Shared ReadOnly currentExecutablePath = Process.GetCurrentProcess().MainModule.FileName
+    Private Shared ReadOnly currentExecutablePath = My.Application.Info.DirectoryPath
     Private Shared ReadOnly executableName = Process.GetCurrentProcess().MainModule.ModuleName
 
     Private AutoStartShell As WshShell
@@ -13,7 +12,7 @@ Public Class AutoStart
         Try
             AutoStartShell = New WshShell
             StartupLink = CType(AutoStartShell.CreateShortcut(GetStartupDirectory() & "\" & GetExecutableName() & ".lnk"), IWshShortcut)
-            StartupLink.TargetPath = GetCurrentExecutablePath()
+            StartupLink.TargetPath = GetCurrentExecutablePath() & "\" & GetExecutableName()
             StartupLink.Save()
         Catch ex As Exception
             MsgBox(ex.Message)
@@ -24,7 +23,7 @@ Public Class AutoStart
         Try
             My.Computer.FileSystem.DeleteFile(GetLinkPath())
         Catch ex As Exception
-            MsgBox("Couldn't delete auto start link:" & ex.Message)
+            MsgBox("Couldn't delete auto start link: " & ex.Message)
         End Try
 
     End Sub
@@ -33,15 +32,15 @@ Public Class AutoStart
         Return CType(GetStartupDirectory() & "\" & GetExecutableName() & ".lnk", String)
     End Function
 
-    Public Shared Function GetStartupDirectory()
+    Public Shared Function GetStartupDirectory() As String
         Return startupFolderPath
     End Function
 
-    Public Shared Function GetCurrentExecutablePath()
-        Return currentExecutablePath
+    Public Shared Function GetCurrentExecutablePath() As String
+        Return currentExecutablePath.ToString()
     End Function
 
-    Public Shared Function GetExecutableName()
+    Public Shared Function GetExecutableName() As String
         Return executableName
     End Function
 

--- a/UpdateDateNTime/Window.vb
+++ b/UpdateDateNTime/Window.vb
@@ -7,19 +7,18 @@ Public Class Window
         Shell("cmd /k start " & profileURL, AppWinStyle.Hide)
     End Sub
     Public Sub UpdateTime()
-        Dim fileName As String = "Resources\update.cmd"
-        Dim command As String = "cmd /k start " & fileName
-        Shell(command, AppWinStyle.Hide)
+        Dim fileName As String = AutoStart.GetCurrentExecutablePath() & "\Resources\update.cmd"
+        Shell("cmd /k start " & fileName, AppWinStyle.Hide)
     End Sub
     Private Sub Window_Load(sender As Object, e As EventArgs) Handles MyBase.Load
         UpdateTime()
-        If My.Computer.FileSystem.FileExists(AutoStart.GetLinkPath) Then
+        If My.Computer.FileSystem.FileExists(AutoStart.GetLinkPath()) Then
             AutoStartCheckBox.Checked = True
         End If
     End Sub
     Private Sub Window_LoadFocused(sender As Object, e As EventArgs) Handles MyBase.GotFocus, MyBase.Load
         ' Start minimized if autostart is on
-        If My.Computer.FileSystem.FileExists(AutoStart.GetLinkPath) Then
+        If My.Computer.FileSystem.FileExists(AutoStart.GetLinkPath()) Then
             WindowState = FormWindowState.Normal
             NotifyIcon.Visible = True
             Hide()


### PR DESCRIPTION
# What's Changed?
- :boom: This patch fixes Issue #3. the app now runs the script with its full directory, instead of using the current working path.